### PR TITLE
Crash log on clipboard for Android and env script for build

### DIFF
--- a/n_player/android/src/main/java/com/enn3developer/n_music/MainActivity.kt
+++ b/n_player/android/src/main/java/com/enn3developer/n_music/MainActivity.kt
@@ -9,6 +9,8 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -102,6 +104,13 @@ class MainActivity : NativeActivity() {
         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
         }
         startActivityForResult(intent, ASK_FILE)
+    }
+
+    @Suppress("unused")
+    private fun set_clipboard_text(text: String){
+        val clipboard: ClipboardManager = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText(text, text)
+        clipboard.setPrimaryClip(clip)
     }
 
     @Suppress("unused")

--- a/n_player/compile_rust.sh
+++ b/n_player/compile_rust.sh
@@ -1,1 +1,2 @@
+source env.sh
 cargo ndk -t arm64-v8a -o android/src/main/jniLibs/ -p 30 build --package n_player --lib --no-default-features

--- a/n_player/compile_rust_release.sh
+++ b/n_player/compile_rust_release.sh
@@ -1,1 +1,2 @@
+source env.sh
 cargo ndk -t arm64-v8a -o android/src/main/jniLibs/ -p 30 build --package n_player --lib --no-default-features --release

--- a/n_player/env.sh
+++ b/n_player/env.sh
@@ -1,0 +1,5 @@
+export ANDROID_HOME=$HOME/Android/Sdk;
+export NDK_VERSION=$(ls $ANDROID_HOME/ndk | head -1);
+export ANDROID_NDK=$ANDROID_HOME/ndk/$NDK_VERSION;
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk;
+export ANDROID_NDK_HOME=$ANDROID_NDK

--- a/n_player/src/platform.rs
+++ b/n_player/src/platform.rs
@@ -221,7 +221,17 @@ impl AndroidPlatform {
 #[cfg(target_os = "android")]
 #[async_trait]
 impl Platform for AndroidPlatform {
-    fn set_clipboard_text(&mut self, text: String) {}
+    fn set_clipboard_text(&mut self, text: String) {
+        let mut env = self.jvm.attach_current_thread().unwrap();
+        let java_string = env.new_string(text).unwrap();
+        env.call_method(
+            &self.callback,
+            "set_clipboard_text",
+            "(Ljava/lang/String;)V",
+            &[(&java_string).into()],
+        )
+        .unwrap();
+    }
 
     async fn open_link(&self, link: String) {
         let mut env = self.jvm.attach_current_thread().unwrap();


### PR DESCRIPTION
Implemented crash logs also on Android and added a simple bash script that sets the env for the build.