### PR TITLE
fix: update image-decoding deps to patch jxl-grid & webp CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +603,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "cfg_aliases",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -2894,9 +2919,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "jpeg-encoder"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b454d911ac55068f53495488d8ccd0646eaa540c033a28ee15b07838afafb01f"
+checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
 
 [[package]]
 name = "js-sys"
@@ -2910,18 +2935,18 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.4.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5855ff16398ffbcf81fee52c41ca65326499c8764b21bb9952c367ace98995fb"
+checksum = "b480e752277e29eb4054f69546887a9b84656fe78c08f54ba5850ced98a378fe"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.4.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5b5093904e940bc11ef50e872c7bdf7b6e88653f012b925f8479daf212b5c9"
+checksum = "cd972bcd125e776f1eb241ac50e39f956095a1c2770c64736c968f8946bd9a3c"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -2929,28 +2954,31 @@ dependencies = [
 
 [[package]]
 name = "jxl-color"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb1c31e10054079df585633fc14fb9e4c96565c58c05b983c502e2472b57fa0"
+checksum = "f316b1358c1711755b3ee8e8cb5c4a1dad12e796233088a7a513440782de80b2"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
+ "jxl-image",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-frame"
-version = "0.9.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35b289aa0f24044167d83a1c29ae2b99210c5082ab7e3e90dacbcae818aa0a2"
+checksum = "2d967c6fd669c7c01060b5022d8835fa82fd46b06ffc98b549f17600a097c2b3"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
  "jxl-image",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "jxl-vardct",
  "tracing",
@@ -2958,60 +2986,92 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.4.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b96735a85299a6bce8664643fcb759f29ea73ce344a90b6f7de9b92a8e9b2d"
+checksum = "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-image"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b31b17ed3bd0e3b65e7b06628f5930e009dda6cd17638cf5159a20a3feedec6"
+checksum = "c5f752d62577c702a94dbbce4045caf08cb58639e8a4d56464b40ecf33ffe565"
 dependencies = [
  "jxl-bitstream",
- "jxl-color",
  "jxl-grid",
+ "jxl-oxide-common",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-jbr"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35d032bcec660647828527ff42c6f5776d2fd44b8357f9f6d9ac6dc07218e46"
+dependencies = [
+ "brotli-decompressor",
+ "jxl-bitstream",
+ "jxl-frame",
+ "jxl-grid",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-modular"
-version = "0.7.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3b9fb8f46e63a14ecedefbd0f873b04162aaf8a09676b630c31bc8dadc4638"
+checksum = "2a2f045b24c738dd91d482be385512b512721ae08a671bd4b27bf1c47f215235"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-oxide"
-version = "0.8.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba1ee3895e6c62b131994807b1ee6d179013613a86c01c203369af8d1e8d2f0"
+checksum = "d36c662923f47586880211f3bc7c0d83fb3a9b410d278c7bde93450748abeef3"
 dependencies = [
+ "brotli-decompressor",
  "jxl-bitstream",
  "jxl-color",
  "jxl-frame",
  "jxl-grid",
  "jxl-image",
+ "jxl-jbr",
+ "jxl-oxide-common",
  "jxl-render",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
-name = "jxl-render"
-version = "0.8.2"
+name = "jxl-oxide-common"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203a79b3025b86f875cc97a6f39e1fcc6314f915b2f6b69f767fca45fd482a11"
+checksum = "b62394c5021b3a9e7e0dbb2d639d555d019090c9946c39f6d3b09d390db4157b"
 dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34386bfdb6a19b5a30cc9beb4d475d537422c31ae8c39bb69640fcce3fcaf19"
+dependencies = [
+ "bytemuck",
  "jxl-bitstream",
  "jxl-coding",
  "jxl-color",
@@ -3019,6 +3079,7 @@ dependencies = [
  "jxl-grid",
  "jxl-image",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "jxl-vardct",
  "tracing",
@@ -3026,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9c78eaf899cce165e266300f9963d8d376d4ed95cf4d12dd7066f05542cd88"
+checksum = "25f15eb830aa77a7f21148d72e153562a26bfe570139bd4922eab1908dd499d3"
 dependencies = [
  "rayon",
  "rayon-core",
@@ -3037,14 +3098,15 @@ dependencies = [
 
 [[package]]
 name = "jxl-vardct"
-version = "0.7.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16af82a1ad770887cad720bfd3cc6a6d023faf377036989a24cf2c6538b649e0"
+checksum = "ce72a18c6d3a47172ab6c479be2bdb56f22066b5d7092663f03b4490820b4511"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
  "jxl-grid",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
@@ -3436,6 +3498,16 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -4664,6 +4736,12 @@ dependencies = [
  "num-traits",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -7922,9 +8000,9 @@ dependencies = [
 
 [[package]]
 name = "zune-bmp"
-version = "0.5.0-rc4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42da113b25df89826a7a8a026bccbaeca252e0e21e6cddbd1caabc1ca2bd948d"
+checksum = "1b77b890dbf6b1a32fc57d9f1f30e22175694c454581de7c6e466f2853cf9fe3"
 dependencies = [
  "log",
  "zune-core 0.5.1",
@@ -7944,9 +8022,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-image"
-version = "0.5.0-rc0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29cd015d9786939132d9ffc1400f5fc4000dae1b6865c916376f22899e0421c"
+checksum = "d67f66717c2ca4f5fe18894e4724c7d22076dea8f245ea5386a05a4b6b8f4a53"
 dependencies = [
  "bytemuck",
  "jpeg-encoder",
@@ -7960,10 +8038,11 @@ dependencies = [
 
 [[package]]
 name = "zune-imageprocs"
-version = "0.5.0-rc0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0eaf7c6a04af776634ae0928dd70d1f4a37f0d9de28a0deae35da2009f3aa2"
+checksum = "915f2f441a4fe4a113839e6e0832c91516f09137f6421b3ce834d3db3ff1b067"
 dependencies = [
+ "moxcms",
  "zune-core 0.5.1",
  "zune-image",
 ]
@@ -7997,18 +8076,18 @@ dependencies = [
 
 [[package]]
 name = "zune-jpegxl"
-version = "0.5.0-rc1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684c65a36dd1f7993d01a5431fb23d23069c74409254b27ef4654e698217617e"
+checksum = "cba11ecd07cc23351500e840ae03841b7e4997923ec8e4832ee3ae199ea0b6b4"
 dependencies = [
  "zune-core 0.5.1",
 ]
 
 [[package]]
 name = "zune-png"
-version = "0.5.0-rc1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea7c0417bae97900becb562db25de02ff87847e11a0a2585ce863b896e7bcee"
+checksum = "5a321146329f7617ba0a5b26982cba45b7ce78163135aba78be25850aefcea80"
 dependencies = [
  "zune-core 0.5.1",
  "zune-inflate",

--- a/n_player/Cargo.toml
+++ b/n_player/Cargo.toml
@@ -28,9 +28,9 @@ serde_json = "1.0"
 n_audio = { path = "../n_audio" }
 flume = "0.12"
 multitag = "0.4"
-zune-image = { version = "0.5.0-rc0", default-features = false, features = ["png", "jpeg", "jpeg-xl", "bmp", "threads"] }
-zune-imageprocs = "0.5.0-rc0"
-zune-core = { version = "0.5.0-rc2", default-features = false, features = ["std"] }
+zune-image = { version = "0.5", default-features = false, features = ["png", "jpeg", "jpeg-xl", "bmp", "threads"] }
+zune-imageprocs = "0.5.1"
+zune-core = { version = "0.5.1", default-features = false, features = ["std"] }
 rimage = { version = "0.12.0", default-features = false, features = ["mozjpeg", "resize", "threads", "webp"] }
 tempfile = "3.20"
 tokio = { version = "1.45", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }


### PR DESCRIPTION
## AI Usage Disclaimer

This PR was prepared by Claude (Anthropic's AI assistant), at the repo owner's (@Enn3Developer) request, working in an agentic chat session. The owner asked me to audit the repo for security issues and, after review, authorized me to push this specific fix and open this PR using a scoped personal access token. I'm disclosing this so reviewers/contributors know an AI produced the diff and this description — please review it with that in mind, same as you would any external contribution.

## What this fixes

Two RustSec advisories reachable through this app's actual attack surface (audio files with embedded cover art, opened by the user):

- **RUSTSEC-2026-0151** — `jxl-grid` < 0.6.2 has an integer-overflow out-of-bounds write when decoding a crafted JPEG XL image (potential memory corruption / code execution, worse on 32-bit targets). Reachable via `zune-image` → `jxl-oxide` → `jxl-grid`, which is exactly the path `get_image_squared()` in `n_player/src/lib.rs` uses to decode cover art extracted from track tags.
- **RUSTSEC-2024-0443** — `webp` 0.3.0 doesn't validate the input buffer size when encoding, causing an out-of-bounds read (memory exposure / possible crash). Pulled in via `rimage`'s `webp` feature.

## Change

Bumped `zune-image`/`zune-core`/`zune-imageprocs` in `n_player/Cargo.toml` off their long-stale release-candidate pins (`0.5.0-rc0`/`0.5.0-rc2`) to the now-stable `0.5.x` releases. That change alone is what pulls in the fix:

- `zune-image 0.5.0` requires `jxl-oxide ^0.12.5`, which resolves to `0.12.6`, which requires `jxl-grid ^0.6.2` (patched).
- `rimage`'s existing `webp ^0.3` constraint resolves to `0.3.1` (patched) once `Cargo.lock` is regenerated.

## Verification performed

I don't have push/CI access from my sandbox and its Rust toolchain (1.75) is too old to build this workspace at all (unrelated — `rand 0.10` already needs edition2024 / Rust 1.85+ transitively). So I could not run a full `cargo build` here. What I did verify:

- Ran `cargo generate-lockfile` against the live crates.io index with the updated `Cargo.toml` — resolves cleanly with `jxl-grid 0.6.2`, `jxl-oxide 0.12.6`, `webp 0.3.1`, `zune-image 0.5.0`, `zune-core 0.5.1`, `zune-imageprocs 0.5.1`, `rimage 0.12.3`. No dependency conflicts.
- Diffed the actual function signatures this codebase calls (`Image::read`, `DecoderOptions::new_fast`, `convert_color`, `zune_imageprocs::crop::Crop::new`, `rimage::operations::resize::Resize::new`, `rimage::codecs::webp::WebPDecoder::try_new`/`decode`) against the new crate sources — all unchanged.

**This PR still needs `Cargo.lock` regenerated and a real `cargo check --workspace` / `cargo build` run on CI or your machine before merging.** Suggested command:

```
cargo update -p jxl-grid -p webp -p zune-image -p zune-core -p zune-imageprocs -p rimage
```

## Other findings from the review (not included here)

A few lower-priority/harder-to-automate items came up during the audit that aren't part of this PR: several `.unwrap()`s on cover-art decode/resize operations that could panic on a malformed (not necessarily malicious) embedded image, a `zstd` decompression call in `settings.rs` with no output-size cap, and the `unsafe impl Send/Sync for TrackData` in `lib.rs` worth a second look for actual cross-thread mutation. Happy to open follow-up PRs for any of these if wanted.
